### PR TITLE
[AP-3634] Renamed docker/build to docker/gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Build inside Docker (recommended)
 
-`docker build -t align-web -f docker/build/Dockerfile .`
+`docker build -t align-web -f docker/gradle/Dockerfile .`
 
 ### With gradle only (no Docker)
 

--- a/docker/gradle/Dockerfile
+++ b/docker/gradle/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:6.9-jdk11-hotspot AS build
+
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon -x test
+
+FROM azul/zulu-openjdk-alpine:11
+
+COPY --from=build ["/home/gradle/src/web/build/libs/web-*.jar", "app/alignment-web.jar"]
+COPY ["docker/prod/entrypoint.sh", "/entrypoint.sh"]
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
build was ignored

Relates to #AP-3634